### PR TITLE
fix: prevent interactions on locked dropdowns

### DIFF
--- a/src/components/ui/Dropdown.lua
+++ b/src/components/ui/Dropdown.lua
@@ -18,7 +18,7 @@ local Tween = Creator.Tween
 
 local TabBackgroundTransparency = 0.67
 
-function DropdownMenu.New(Config, Dropdown, Element, CanCallback, Type)
+function DropdownMenu.New(Config, Dropdown, Element, Type)
 	local DropdownModule = {}
 
 	if not Dropdown.Callback then
@@ -175,12 +175,22 @@ function DropdownMenu.New(Config, Dropdown, Element, CanCallback, Type)
 
 	local function Callback(customCallback)
 		DropdownModule:Display()
+		if Dropdown.Locked then
+			return
+		end
+
 		if Dropdown.Callback then
 			task.spawn(function()
+				if Dropdown.Locked then
+					return
+				end
 				Creator.SafeCallback(Dropdown.Callback, Dropdown.Value)
 			end)
 		else
 			task.spawn(function()
+				if Dropdown.Locked then
+					return
+				end
 				Creator.SafeCallback(customCallback)
 			end)
 		end
@@ -455,7 +465,7 @@ function DropdownMenu.New(Config, Dropdown, Element, CanCallback, Type)
 
 				if Type == "Dropdown" then
 					Creator.AddSignal(TabMain.UIElements.TabItem.MouseButton1Click, function()
-						if TabMain.Locked then
+						if Dropdown.Locked or TabMain.Locked then
 							return
 						end
 
@@ -527,7 +537,7 @@ function DropdownMenu.New(Config, Dropdown, Element, CanCallback, Type)
 						end)
 					end
 					Creator.AddSignal(TabMain.UIElements.TabItem.MouseButton1Click, function()
-						if TabMain.Locked then
+						if Dropdown.Locked or TabMain.Locked then
 							return
 						end
 						Callback(Tab.Callback or function() end)
@@ -580,7 +590,7 @@ function DropdownMenu.New(Config, Dropdown, Element, CanCallback, Type)
 	RecalculateCanvasSize()
 
 	function DropdownModule:Open()
-		if CanCallback then
+		if not Dropdown.Locked then
 			Dropdown.UIElements.Menu.Visible = true
 			Dropdown.UIElements.MenuCanvas.Visible = true
 			Dropdown.UIElements.MenuCanvas.Active = true
@@ -592,6 +602,9 @@ function DropdownMenu.New(Config, Dropdown, Element, CanCallback, Type)
 
 			task.spawn(function()
 				task.wait(0.1)
+				if Dropdown.Locked then
+					return
+				end
 				Dropdown.Opened = true
 			end)
 

--- a/src/elements/Dropdown.lua
+++ b/src/elements/Dropdown.lua
@@ -56,8 +56,6 @@ function Element:New(Config)
 		Dropdown.Value = Dropdown.Values[Dropdown.Value]
 	end
 
-	local CanCallback = true
-
 	Dropdown.DropdownFrame = require("../components/window/Element")({
 		Title = Dropdown.Title,
 		Desc = Dropdown.Desc,
@@ -90,7 +88,7 @@ function Element:New(Config)
 		-- })
 	end
 
-	Dropdown.DropdownMenu = CreateDropdown(Config, Dropdown, Element, CanCallback, "Dropdown")
+	Dropdown.DropdownMenu = CreateDropdown(Config, Dropdown, Element, "Dropdown")
 
 	Dropdown.Display = Dropdown.DropdownMenu.Display
 	Dropdown.Refresh = Dropdown.DropdownMenu.Refresh
@@ -114,12 +112,13 @@ function Element:New(Config)
 
 	function Dropdown:Lock()
 		Dropdown.Locked = true
-		CanCallback = false
+		if Dropdown.Opened or Dropdown.UIElements.MenuCanvas.Visible then
+			Dropdown:Close()
+		end
 		return Dropdown.DropdownFrame:Lock(Dropdown.LockedTitle)
 	end
 	function Dropdown:Unlock()
 		Dropdown.Locked = false
-		CanCallback = true
 		return Dropdown.DropdownFrame:Unlock()
 	end
 


### PR DESCRIPTION
## Summary

Fixes a critical issue where locked dropdowns could still be opened, selected values could be changed, and callbacks could be triggered.

## Changes

- Use the shared `Dropdown.Locked` state instead of a stale copied boolean.
- Prevent locked dropdowns from opening.
- Prevent item selection and value changes while locked.
- Block callbacks when the dropdown is locked.
- Close the menu if the dropdown is locked while open.
- Handle delayed opening safely.

## Testing

- Verified the final diff with `git diff --check`.
- Confirmed all internal factory calls use the updated signature.
- Locally compiled and tested. No regressions found and the fix works.

Closes #93 